### PR TITLE
Upload of a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # grunt-artifactory-artifact
-Forked from grunt-artifactory-artifact https://github.com/leedavidr/grunt-artifactory-artifact
-This is a publish-only version, fixing a few bugs from the original (e.g. parameters now work).
-> Publish artifacts to a JFrog Artifactory artifact repository.
-> Only works with Mac and Linux
+Forked from grunt-artifactory-artifact https://github.com/leedavidr/grunt-artifactory-publish
+Enables to publish a file (e.g. a compressed archive or pom)
 
 ## Why?
 If you're using grunt for frontend development and Java for the backend, it is convenient to consolidate dependencies into one repository.
@@ -59,6 +57,13 @@ artifactory: {
       ]
     }
   }
+  pom: {
+	options: {
+		id: com.mycompany.js:built-artifact:pom',
+		version: 'my-version',
+		publishSingleFile: true
+	}
+  }
 }
 ```
 
@@ -86,9 +91,13 @@ Type 'Boolean'
 
 When 'true', the artifact will attempt to be decompressed. Defaults to 'true'. Currently supports extensions 'tgz','jar','zip', and 'war'.
 
-
 This parameter comes from `grunt-contrib-compress`. You can read about it at [github.com/gruntjs/grunt-contrib-compress](https://github.com/gruntjs/grunt-contrib-compress).
 There are some differences from the config on `grunt-contrib-compress`. First of all, `ext` is used from the artifact, so it doesn't need to be specified. `mode` is currently not supported. It will auto-configure based on the extension.
+
+#### publishSingleFile
+Type 'Boolean'
+
+Publishes the file directly to the Artifactory, skipping the compression step. Useful to publish e.g. a single .pom file (filename in this example is 'built-artifact-<my-version>.pom') to the Artifactory
 
 # Release History
 * 2013-08-08  v0.2.0  Added support for publishing artifacts

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ artifactory: {
   }
   pom: {
 	options: {
-		id: com.mycompany.js:built-artifact:pom',
+		id: 'com.mycompany.js:built-artifact:pom',
 		version: 'my-version',
 		publishSingleFile: true
 	}

--- a/tasks/artifactory.coffee
+++ b/tasks/artifactory.coffee
@@ -35,6 +35,8 @@ module.exports = (grunt) ->
           deferred.resolve()
           .fail (err) ->
             deferred.reject(err)
+        .fail (err) ->
+          deferred.reject(err)
       else
         util.package(artifact, @files, { path: options.path }).then () ->
           util.publish(artifact, publishOptions).then ()->

--- a/tasks/artifactory.coffee
+++ b/tasks/artifactory.coffee
@@ -34,15 +34,15 @@ module.exports = (grunt) ->
         util.publish(artifact, publishOptions).then ()->
           deferred.resolve()
           .fail (err) ->
-          deferred.reject(err)
+            deferred.reject(err)
       else
         util.package(artifact, @files, { path: options.path }).then () ->
           util.publish(artifact, publishOptions).then ()->
             deferred.resolve()
             .fail (err) ->
-            deferred.reject(err)
+              deferred.reject(err)
           .fail (err) ->
-          deferred.reject(err)
+            deferred.reject(err)
       processes.push deferred.promise
 
     Q.all(processes).then(() ->

--- a/tasks/artifactory.coffee
+++ b/tasks/artifactory.coffee
@@ -18,6 +18,7 @@ module.exports = (grunt) ->
       versionPattern: '%a-%v%c.%e'
       username: ''
       password: ''
+      publishSingleFile: false
 
     processes = []
 
@@ -28,12 +29,19 @@ module.exports = (grunt) ->
 
       artifact = new ArtifactoryArtifact artifactCfg
       deferred = Q.defer()
-      util.package(artifact, @files, { path: options.path }).then () ->
-          util.publish(artifact, { path: options.path, credentials: { username: options.username, password: options.password }, parameters: options.parameters}).then ()->
-              deferred.resolve()
+      publishOptions = { path: options.path, credentials: { username: options.username, password: options.password }, parameters: options.parameters}
+      if options.publishSingleFile
+        util.publish(artifact, publishOptions).then ()->
+          deferred.resolve()
           .fail (err) ->
-              deferred.reject(err)
-      .fail (err) ->
+          deferred.reject(err)
+      else
+        util.package(artifact, @files, { path: options.path }).then () ->
+          util.publish(artifact, publishOptions).then ()->
+            deferred.resolve()
+            .fail (err) ->
+            deferred.reject(err)
+          .fail (err) ->
           deferred.reject(err)
       processes.push deferred.promise
 


### PR DESCRIPTION
Added support to upload a single file to a JFrog Artifactory.
The feature is used e.g. to uplad a pom file, as the feature request [Generate POM for artifacts deployed via the REST API?](https://www.jfrog.com/jira/browse/RTFACT-4416) is not yet implemented